### PR TITLE
add a random diff so PR can be triggerd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 =============================================
-MLflow: A Machine Learning Lifecycle Platform
+MLflow: A Machine Learning Lifecycle
 =============================================
 
 MLflow is a platform to streamline machine learning development, including tracking experiments, packaging code

--- a/mlflow/johnsnowlabs.py
+++ b/mlflow/johnsnowlabs.py
@@ -143,18 +143,10 @@ def get_default_pip_requirements():
         "https://pypi.johnsnowlabs.com/{secret}/spark-nlp-jsl/spark_nlp_jsl-"
         + f"{settings.raw_version_medical}-py3-none-any.whl"
     )
-    if databricks_utils.is_in_databricks_runtime():
-        deps = [
-            f"johnsnowlabs_for_databricks=={settings.raw_version_jsl_lib}",
-            _get_pinned_requirement("pyspark"),
-        ]
-    else:
-        deps = [
-            f"johnsnowlabs=={settings.raw_version_jsl_lib}",
-        ]
 
     return [
-        *deps,
+        f"johnsnowlabs_for_databricks=={settings.raw_version_jsl_lib}",
+        _get_pinned_requirement("pyspark"),
         _SPARK_NLP_JSL_WHEEL_URI.format(secret=os.environ["SECRET"]),
         # TODO remove pandas constraint when NLU supports it
         # https://github.com/JohnSnowLabs/nlu/issues/176


### PR DESCRIPTION
## Related Issues/PRs
https://github.com/mlflow/mlflow/issues/8552 

## What changes are proposed in this pull request?

This PR introduces a new flavor, `johnsnowlabs` to mlflow.
Since all Johnsnowlabs models are stored as Spark ML PipelineModels,  the implementation is very similar to the existing `spark` flavor.
90% of the code in the `mlflow.johnsnowlabs` module and the `test_johnsnowlabs.py` file are based on the corresponding `mlflow.spark` and `test_spark_model_export.py` modules and every test has been replicated except the `test_pyspark_version_is_logged_without_dev_suffix` test, since for now the pyspark version is fixed via the johnsnowlabs library.

Only minor changes have been added, to handle `license checks` and starting a `sparksession` with appropriate jars and configs.
Models can be exported as `pyfunc` and `johnsnowlabs` flavor, both will contain all the jars required to serve the model from via `mlflow serve`  as docker/locally.
`mleap` should also work, but is not tested yet. 

  
These keys must be present in the json string of the  `JOHNSNOWLABS_LICENSE_JSON`  variable
- `SECRET`: The secret for the John Snow Labs Enterprise NLP Library
- `SPARK_NLP_LICENSE`: Your John Snow Labs Enterprise NLP License
- `AWS_ACCESS_KEY_ID`: Your AWS Secret ID for accessing John Snow Labs Enterprise Models
- `AWS_SECRET_ACCESS_KEY`: Your AWS Secret key for accessing John Snow Labs Enterprise Models

## Example notebooks
- [Databricks example notebook ](https://github.com/mlflow/mlflow/files/11588999/mlflow_johnsnowlabs_flavor.txt)
 this is a notebook .html file saved as .txt so github lets me upload it

- [Google Colab example Notebook ](https://colab.research.google.com/drive/1mvm605wZ9HZNaKK6XlGqF35edSsgYesn?usp=sharing)



## Usage

Export a johnsnowlabs model to mlflow formats
```python
from johnsnowlabs import nlp
import mlflow
import os

# Define environment variables, provided to you by johnsnowlabs
os.environ[ "JOHNSNOWLABS_LICENSE_JSON"] = \
'{"AWS_ACCESS_KEY_ID":"...", "AWS_SECRET_ACCESS_KEY":"...", "SPARK_NLP_LICENSE":"...", "SECRET":"..."}'


# Download & Install Jars/Wheels if missing and Start a spark Session
nlp.start()

# load a model
model = nlp.load('tokenize')

# log model to mlflow server 
mlflow.johnsnowlabs.log_model(model, 'logged_model')

# Save model as pyfunc and johnsnowlabs format
mlflow.johnsnowlabs.save_model(model, 'saved_model')
model = mlflow.johnsnowlabs.load_model('saved_model')

# Save model as mleap
# todo 

```


build mlflow container
```shell
mlflow models build-docker --model-uri "MY_MODEL" --name "mlflow-pyfunc"
```

deploy local container (pyfunc format)
```shell
docker run -p 5001:8080 -e JOHNSNOWLABS_LICENSE_JSON=JSON_STRING "mlflow-pyfunc"
```


Query server
```shell
curl http://127.0.0.1:5001/invocations -H 'Content-Type: application/json' -d '{
  "dataframe_split": {                 
      "columns": ["text"],
      "data": [ [ "I hate covid"], ["I love covid"]]
  }
}'
```


alternatively local serve non-container based 
```shell
export JOHNSNOWLABS_LICENSE_JSON=JSON_STRING
mlflow models serve -m /MY_MODEL
```

then send data to server

```shell 
curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
  "dataframe_split": {                 
      "columns": ["text"],
      "data": [ [ "I hate covid"], ["I love covid"]]
  }
}'
```



### Example notebooks



## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)
tested `mlflow serve` with docker container and containerless locally as well as replicating every test in`test_spark_model_export.py` for the new module

### Note regarding Usage inside of Databricks : 

when using `mlflow models serrve - my/model`  and call `SparkContext.getOrCreate()` I get this error message, telling me to use `SparkContext.getOrCreate()` to fetch a spark context. 
Maybe there is a bug in the Databricks/Spark environment I used, I will try the latest compatible later hopefully its fixed there

```
py4j.protocol.Py4JJavaError: An error occurred while calling None.org.apache.spark.api.java.JavaSparkContext.
: org.apache.spark.SparkException: In Databricks, developers should utilize the shared SparkContext instead of creating one using the constructor. In Scala and Python notebooks, the shared context can be accessed as sc. When running a job, you can access the shared context by calling SparkContext.getOrCreate(). The other SparkContext was created at:
```
For the full error Stack, see : 


```sh
2023/05/26 22:49:07 INFO mlflow.models.flavor_backend_registry: Selected backend for flavor 'python_function'
2023/05/26 22:49:07 INFO mlflow.utils.virtualenv: Installing python 3.8.10 if it does not exist
2023/05/26 22:49:07 INFO mlflow.utils.virtualenv: Environment /root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042 already exists
2023/05/26 22:49:07 INFO mlflow.utils.environment: === Running command '['bash', '-c', 'source /root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/bin/activate && python -c ""']'
2023/05/26 22:49:08 INFO mlflow.utils.environment: === Running command '['bash', '-c', 'source /root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/bin/activate && exec gunicorn --timeout=60 -b 127.0.0.1:5000 -w 1 ${GUNICORN_CMD_ARGS} -- mlflow.pyfunc.scoring_server.wsgi:app']'
[2023-05-26 22:49:08 +0000] [14357] [INFO] Starting gunicorn 20.1.0
[2023-05-26 22:49:08 +0000] [14357] [INFO] Listening at: http://127.0.0.1:5000 (14357)
[2023-05-26 22:49:08 +0000] [14357] [INFO] Using worker: sync
[2023-05-26 22:49:08 +0000] [14361] [INFO] Booting worker with pid: 14361
[2023-05-26 22:49:12 +0000] [14361] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/gunicorn/arbiter.py", line 589, in spawn_worker
    worker.init_process()
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/gunicorn/workers/base.py", line 134, in init_process
    self.load_wsgi()
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/gunicorn/workers/base.py", line 146, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 58, in load
    return self.load_wsgiapp()
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/gunicorn/util.py", line 359, in import_app
    mod = importlib.import_module(module)
  File "/root/.pyenv/versions/3.8.10/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/mlflow/pyfunc/scoring_server/wsgi.py", line 6, in <module>
    app = scoring_server.init(load_model(os.environ[scoring_server._SERVER_MODEL_PATH]))
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/mlflow/pyfunc/__init__.py", line 596, in load_model
    model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/mlflow/johnsnowlabs.py", line 707, in _load_pyfunc
    return _PyFuncModelWrapper(_load_model(model_uri=path), get_or_create_sparksession(path))
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/mlflow/johnsnowlabs.py", line 616, in _load_model
    get_or_create_sparksession(local_model_path)
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/mlflow/johnsnowlabs.py", line 735, in get_or_create_sparksession
    spark = nlp.start(nlp=False, spark_nlp=False, jar_paths=jar_paths, json_license_path=license_path,
  File "/root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/lib/python3.8/site-packages/johnsnowlabs/utils/sparksession_utils.py", line 200, in start
    spark = builder.getOrCreate()
  File "/databricks/spark/python/pyspark/sql/session.py", line 229, in getOrCreate
    sc = SparkContext.getOrCreate(sparkConf)
  File "/databricks/spark/python/pyspark/context.py", line 400, in getOrCreate
    SparkContext(conf=conf or SparkConf())
  File "/databricks/spark/python/pyspark/context.py", line 147, in __init__
    self._do_init(master, appName, sparkHome, pyFiles, environment, batchSize, serializer,
  File "/databricks/spark/python/pyspark/context.py", line 210, in _do_init
    self._jsc = jsc or self._initialize_context(self._conf._jconf)
  File "/databricks/spark/python/pyspark/context.py", line 337, in _initialize_context
    return self._jvm.JavaSparkContext(jconf)
  File "/databricks/spark/python/lib/py4j-0.10.9.1-src.zip/py4j/java_gateway.py", line 1568, in __call__
    return_value = get_return_value(
  File "/databricks/spark/python/lib/py4j-0.10.9.1-src.zip/py4j/protocol.py", line 326, in get_return_value
    raise Py4JJavaError(
py4j.protocol.Py4JJavaError: An error occurred while calling None.org.apache.spark.api.java.JavaSparkContext.
: org.apache.spark.SparkException: In Databricks, developers should utilize the shared SparkContext instead of creating one using the constructor. In Scala and Python notebooks, the shared context can be accessed as sc. When running a job, you can access the shared context by calling SparkContext.getOrCreate(). The other SparkContext was created at:
CallSite(SparkContext at DatabricksILoop.scala:352,org.apache.spark.SparkContext.<init>(SparkContext.scala:111)
com.databricks.backend.daemon.driver.DatabricksILoop$.$anonfun$initializeSharedDriverContext$1(DatabricksILoop.scala:352)
com.databricks.backend.daemon.driver.ClassLoaders$.withContextClassLoader(ClassLoaders.scala:29)
com.databricks.backend.daemon.driver.DatabricksILoop$.initializeSharedDriverContext(DatabricksILoop.scala:352)
com.databricks.backend.daemon.driver.DatabricksILoop$.getOrCreateSharedDriverContext(DatabricksILoop.scala:281)
com.databricks.backend.daemon.driver.DriverCorral.driverContext(DriverCorral.scala:242)
com.databricks.backend.daemon.driver.DriverCorral.<init>(DriverCorral.scala:118)
com.databricks.backend.daemon.driver.DriverDaemon.<init>(DriverDaemon.scala:66)
com.databricks.backend.daemon.driver.DriverDaemon$.create(DriverDaemon.scala:519)
com.databricks.backend.daemon.driver.DriverDaemon$.wrappedMain(DriverDaemon.scala:924)
com.databricks.DatabricksMain.$anonfun$main$1(DatabricksMain.scala:141)
scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
com.databricks.DatabricksMain.$anonfun$withStartupProfilingData$1(DatabricksMain.scala:472)
com.databricks.logging.UsageLogging.$anonfun$recordOperation$1(UsageLogging.scala:336)
com.databricks.logging.UsageLogging.executeThunkAndCaptureResultTags$1(UsageLogging.scala:430)
com.databricks.logging.UsageLogging.$anonfun$recordOperationWithResultTags$4(UsageLogging.scala:451)
com.databricks.logging.Log4jUsageLoggingShim$.$anonfun$withAttributionContext$1(Log4jUsageLoggingShim.scala:34)
scala.util.DynamicVariable.withValue(DynamicVariable.scala:62)
com.databricks.logging.AttributionContext$.withValue(AttributionContext.scala:94)
com.databricks.logging.Log4jUsageLoggingShim$.withAttributionContext(Log4jUsageLoggingShim.scala:32))
	at org.apache.spark.SparkContext$.$anonfun$assertNoOtherContextIsRunning$2(SparkContext.scala:3138)
	at scala.Option.foreach(Option.scala:407)
	at org.apache.spark.SparkContext$.assertNoOtherContextIsRunning(SparkContext.scala:3132)
	at org.apache.spark.SparkContext$.markPartiallyConstructed(SparkContext.scala:3266)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:121)
	at org.apache.spark.api.java.JavaSparkContext.<init>(JavaSparkContext.scala:60)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:247)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:380)
	at py4j.Gateway.invoke(Gateway.java:250)
	at py4j.commands.ConstructorCommand.invokeConstructor(ConstructorCommand.java:80)
	at py4j.commands.ConstructorCommand.execute(ConstructorCommand.java:69)
	at py4j.GatewayConnection.run(GatewayConnection.java:251)
	at java.lang.Thread.run(Thread.java:748)

[2023-05-26 22:49:12 +0000] [14361] [INFO] Worker exiting (pid: 14361)
[2023-05-26 22:49:12 +0000] [14357] [INFO] Shutting down: Master
[2023-05-26 22:49:12 +0000] [14357] [INFO] Reason: Worker failed to boot.
Traceback (most recent call last):
  File "/databricks/python3/bin/mlflow", line 8, in <module>
    sys.exit(cli())
  File "/databricks/python3/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/databricks/python3/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/databricks/python3/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/databricks/python3/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/databricks/python3/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/databricks/python3/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/databricks/python3/lib/python3.8/site-packages/mlflow/models/cli.py", line 105, in serve
    return get_flavor_backend(
  File "/databricks/python3/lib/python3.8/site-packages/mlflow/pyfunc/backend.py", line 231, in serve
    return self.prepare_env(local_path).execute(
  File "/databricks/python3/lib/python3.8/site-packages/mlflow/utils/environment.py", line 593, in execute
    return _exec_cmd(
  File "/databricks/python3/lib/python3.8/site-packages/mlflow/utils/process.py", line 117, in _exec_cmd
    raise ShellCommandException.from_completed_process(comp_process)
mlflow.utils.process.ShellCommandException: Non-zero exit code: 3
Command: ['bash', '-c', 'source /root/.mlflow/envs/mlflow-25cd88fccb6cfc4e557e3c1aad9d2c9d64d31042/bin/activate && exec gunicorn --timeout=60 -b 127.0.0.1:5000 -w 1 ${GUNICORN_CMD_ARGS} -- mlflow.pyfunc.scoring_server.wsgi:app']
```


## Does this PR change the documentation?
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview. TODO render docs

## Release Notes

### Is this a user-facing change?
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support for over 20k+ state-of-the-art enterprise NLP models for finance, legal, healthcare and more domains see https://sparknlp.org/models  and for more info see https://www.johnsnowlabs.com/ 


### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
